### PR TITLE
add support for self & reference placeholders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/README.md
+++ b/README.md
@@ -6,5 +6,7 @@ Works with:
 - `@branch[.property]` direct references
 - `!@branch[.property]` clone referenced branche/property
 - `{$ENV_VAR}` reference process.env variables
+- `&{property}` reference a property from the current (container) branch
+- `"@{branch[.property]}"` in place reference (supported only for string values)
 
 Example usage can be found in tests folder

--- a/index.js
+++ b/index.js
@@ -21,10 +21,12 @@ var resolveValue = function(dna, query) {
   }
 }
 
+var filterMatches = function (value, index, array) {
+  return !index || value !== array[index - 1]
+}
+
 var resolveSelfReferencePlaceholders = function (dna, valueWithPlaceholdes) {
-  var matches = valueWithPlaceholdes.match(re.selfReference).sort().filter(function (value, index, array) {
-    return !index || value !== array[index - 1]
-  })
+  var matches = valueWithPlaceholdes.match(re.selfReference).sort().filter(filterMatches)
 
   for (var i in matches) {
     var match = matches[i].replace(re.selfReferenceStrip, '')
@@ -76,9 +78,7 @@ var walk = function(dna, rootDNA) {
       break
 
       case re.referencePlaceholder.test(dna[key]):
-        var matches = dna[key].match(re.referencePlaceholder).sort().filter(function (value, index, array) {
-          return !index || value !== array[index - 1]
-        })
+        var matches = dna[key].match(re.referencePlaceholder).sort().filter(filterMatches)
 
         for (var i in matches) {
           var match = matches[i].replace(re.referencePlaceholderStrip, '')
@@ -88,9 +88,7 @@ var walk = function(dna, rootDNA) {
       break
 
       case re.processEnv.test(dna[key]):
-        var matches = dna[key].match(re.processEnv).sort().filter(function (value, index, array) {
-          return !index || value !== array[index - 1]
-        })
+        var matches = dna[key].match(re.processEnv).sort().filter(filterMatches)
 
         for (var i in matches) {
           var match = matches[i].replace(re.processEnvStrip, '')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "organic-dna-resolve",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "author": "multi",
   "description": "Shotgun for resolving DNA values",
   "main": "index.js",

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -17,6 +17,17 @@ test('dna resolve', function(t) {
       propertyValueReference: '!@branch.property',
       wholeBranch: '!@branch',
       array: [{'!@': 'branch'}, {'!@': 'branch.property'}]
+    },
+    selfReferenceBranch: {
+      value: 'value',
+      value2: 'value2',
+      containervalue: 'container &{value} &{value2}'
+    },
+    referencedSelfReferenceBranch: {
+      value: '@selfReferenceBranch.containervalue'
+    },
+    placeholderReference: {
+      value: '@{selfReferenceBranch.containervalue} value'
     }
   }
 
@@ -52,6 +63,15 @@ test('dna resolve', function(t) {
   t.is(dna.clonedBranch.array[1], 'value')
 
   t.is(dna.clonedBranch.wholeBranch.PATH, process.env.PATH)
+
+  //
+
+  t.is(dna.selfReferenceBranch.containervalue, 'container value value2')
+  t.is(dna.referencedSelfReferenceBranch.value, 'container value value2')
+
+  //
+
+  t.is(dna.placeholderReference.value, 'container value value2 value')
 
   //
 


### PR DESCRIPTION
+ added .gitignore
+ bumpted version to 0.1.0 (no API changes, no backward compatibility issues)
+ introduced support for self reference placeholders via `&{propertyName}`
+ introduced support for reference placeholders via `"@{propertyPath}"`
+ added tests
+ made sure that existing references `@...`do not collide with `@{...}` by white-listing allowed characters for reference property path as `/^@[A-Za-z0-9_\-\.]+/`